### PR TITLE
HTTPS and File Uploads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 play-with-docker
 node_modules
+docker-compose.single.yml

--- a/Dockerfile.dind
+++ b/Dockerfile.dind
@@ -38,6 +38,8 @@ ENV DOCKER_STORAGE_DRIVER=$docker_storage_driver
 # Move to our home
 WORKDIR /root
 
+RUN mkdir -p /var/run/pwd/certs && mkdir -p /var/run/pwd/uploads
+
 # Remove IPv6 alias for localhost and start docker in the background ...
 CMD cat /etc/hosts >/etc/hosts.bak && \
     sed 's/^::1.*//' /etc/hosts.bak > /etc/hosts && \

--- a/handlers/file_upload.go
+++ b/handlers/file_upload.go
@@ -1,0 +1,47 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/play-with-docker/play-with-docker/services"
+)
+
+func FileUpload(rw http.ResponseWriter, req *http.Request) {
+	vars := mux.Vars(req)
+	sessionId := vars["sessionId"]
+	instanceName := vars["instanceName"]
+
+	s := services.GetSession(sessionId)
+	i := services.GetInstance(s, instanceName)
+
+	// allow up to 32 MB which is the default
+
+	// has a url query parameter, ignore body
+	if url := req.URL.Query().Get("url"); url != "" {
+		err := i.UploadFromURL(req.URL.Query().Get("url"))
+		if err != nil {
+			log.Println(err)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		rw.WriteHeader(http.StatusOK)
+		return
+	} else {
+		// This is for multipart upload
+		log.Println("Not implemented yet")
+
+		/*
+			err := req.ParseMultipartForm(32 << 20)
+			if err != nil {
+				log.Println(err)
+				rw.WriteHeader(http.StatusBadRequest)
+				return
+			}
+		*/
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+}

--- a/handlers/new_instance.go
+++ b/handlers/new_instance.go
@@ -13,7 +13,7 @@ func NewInstance(rw http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	sessionId := vars["sessionId"]
 
-	body := struct{ ImageName, Alias string }{}
+	body := services.InstanceConfig{}
 
 	json.NewDecoder(req.Body).Decode(&body)
 
@@ -26,7 +26,7 @@ func NewInstance(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	i, err := services.NewInstance(s, body.ImageName, body.Alias)
+	i, err := services.NewInstance(s, body)
 	if err != nil {
 		log.Println(err)
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/handlers/tlsproxy.go
+++ b/handlers/tlsproxy.go
@@ -8,12 +8,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/franela/play-with-docker.old/config"
 	vhost "github.com/inconshreveable/go-vhost"
+	"github.com/play-with-docker/play-with-docker/config"
 )
 
 func StartTLSProxy(port string) {
-	var validProxyHost = regexp.MustCompile(`^.*(pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}(?:-[0-9]{1,5})?)\..*$`)
+	var validProxyHost = regexp.MustCompile(`^.*pwd([0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}(?:-[0-9]{1,5})?)\..*$`)
 
 	tlsListener, tlsErr := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	log.Println("Listening on port " + port)
@@ -61,7 +61,7 @@ func StartTLSProxy(port string) {
 				targetPort = target[1]
 			}
 
-			ip := strings.Replace(strings.TrimPrefix(target[0], "pwd"), "_", ".", -1)
+			ip := strings.Replace(target[0], "_", ".", -1)
 
 			if net.ParseIP(ip) == nil {
 				// Not a valid IP, so treat this is a hostname.

--- a/handlers/tlsproxy.go
+++ b/handlers/tlsproxy.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"regexp"
+	"strings"
+
+	"github.com/franela/play-with-docker.old/config"
+	vhost "github.com/inconshreveable/go-vhost"
+)
+
+func StartTLSProxy(port string) {
+	var validProxyHost = regexp.MustCompile(`^.*(pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}(?:-[0-9]{1,5})?)\..*$`)
+
+	tlsListener, tlsErr := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	log.Println("Listening on port " + port)
+	if tlsErr != nil {
+		log.Fatal(tlsErr)
+	}
+	defer tlsListener.Close()
+	for {
+		// Wait for TLS Connection
+		conn, err := tlsListener.Accept()
+		if err != nil {
+			log.Printf("Could not accept new TLS connection. Error: %s", err)
+			continue
+		}
+		// Handle connection on a new goroutine and continue accepting other new connections
+		go func(c net.Conn) {
+			defer c.Close()
+			vhostConn, err := vhost.TLS(conn)
+			if err != nil {
+				log.Printf("Incoming TLS connection produced an error. Error: %s", err)
+				return
+			}
+			defer vhostConn.Close()
+
+			host := vhostConn.ClientHelloMsg.ServerName
+			match := validProxyHost.FindStringSubmatch(host)
+			if len(match) == 2 {
+				// This is a valid proxy host, keep only the important part
+				host = match[1]
+			} else {
+				// Not a valid proxy host, just close connection.
+				return
+			}
+
+			var targetIP string
+			targetPort := "443"
+
+			hostPort := strings.Split(host, ":")
+			if len(hostPort) > 1 && hostPort[1] != config.SSLPortNumber {
+				targetPort = hostPort[1]
+			}
+
+			target := strings.Split(hostPort[0], "-")
+			if len(target) > 1 {
+				targetPort = target[1]
+			}
+
+			ip := strings.Replace(strings.TrimPrefix(target[0], "pwd"), "_", ".", -1)
+
+			if net.ParseIP(ip) == nil {
+				// Not a valid IP, so treat this is a hostname.
+			} else {
+				targetIP = ip
+			}
+
+			dest := fmt.Sprintf("%s:%s", targetIP, targetPort)
+			d, err := net.Dial("tcp", dest)
+			if err != nil {
+				log.Printf("Error dialing backend %s: %v\n", dest, err)
+				return
+			}
+
+			errc := make(chan error, 2)
+			cp := func(dst io.Writer, src io.Reader) {
+				_, err := io.Copy(dst, src)
+				errc <- err
+			}
+			go cp(d, vhostConn)
+			go cp(vhostConn, d)
+			<-errc
+		}(conn)
+	}
+
+}

--- a/services/instance.go
+++ b/services/instance.go
@@ -45,6 +45,14 @@ type Instance struct {
 	cert         *tls.Certificate `json:"-"`
 }
 
+type InstanceConfig struct {
+	ImageName  string
+	Alias      string
+	ServerCert []byte
+	ServerKey  []byte
+	CACert     []byte
+}
+
 func (i *Instance) setUsedPort(port uint16) {
 	rw.Lock()
 	defer rw.Unlock()
@@ -100,17 +108,17 @@ func getDindImageName() string {
 	return dindImage
 }
 
-func NewInstance(session *Session, imageName, alias string) (*Instance, error) {
-	if imageName == "" {
-		imageName = dindImage
+func NewInstance(session *Session, conf InstanceConfig) (*Instance, error) {
+	if conf.ImageName == "" {
+		conf.ImageName = dindImage
 	}
-	log.Printf("NewInstance - using image: [%s]\n", imageName)
-	instance, err := CreateInstance(session, imageName)
+	log.Printf("NewInstance - using image: [%s]\n", conf.ImageName)
+	instance, err := CreateInstance(session, conf)
 	if err != nil {
 		return nil, err
 	}
 
-	instance.Alias = alias
+	instance.Alias = conf.Alias
 
 	instance.session = session
 


### PR DESCRIPTION
Make HTTPS proxying smarter by using SNI.
Allow the creation of instances with certificated (this will make the
PWD docker-machine driver a lot better).
Add endpoint to upload files to instances. Right now it only works with
the `url` querystring parameter. In the near future it will allow to
upload multipart forms.