### PR TITLE
Add support for setting alias when creatign instance.

### DIFF
--- a/api.go
+++ b/api.go
@@ -65,6 +65,8 @@ func main() {
 	// Specific routes
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}.{tld:.*}`).Handler(tcpHandler)
+	r.Host(`{alias:.*}-{session:.*}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
+	r.Host(`{alias:.*}-{session:.*}.{tld:.*}`).Handler(tcpHandler)
 	r.HandleFunc("/ping", handlers.Ping).Methods("GET")
 	corsRouter.HandleFunc("/instances/images", handlers.GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", handlers.GetSession).Methods("GET")

--- a/api.go
+++ b/api.go
@@ -65,8 +65,8 @@ func main() {
 	// Specific routes
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
 	r.Host(`{subdomain:.*}{node:pwd[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}_[0-9]{1,3}}.{tld:.*}`).Handler(tcpHandler)
-	r.Host(`{alias:.*}-{session:.*}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
-	r.Host(`{alias:.*}-{session:.*}.{tld:.*}`).Handler(tcpHandler)
+	r.Host(`pwd{alias:.*}-{session:.*}-{port:[0-9]*}.{tld:.*}`).Handler(tcpHandler)
+	r.Host(`pwd{alias:.*}-{session:.*}.{tld:.*}`).Handler(tcpHandler)
 	r.HandleFunc("/ping", handlers.Ping).Methods("GET")
 	corsRouter.HandleFunc("/instances/images", handlers.GetInstanceImages).Methods("GET")
 	corsRouter.HandleFunc("/sessions/{sessionId}", handlers.GetSession).Methods("GET")

--- a/handlers/new_instance.go
+++ b/handlers/new_instance.go
@@ -13,7 +13,7 @@ func NewInstance(rw http.ResponseWriter, req *http.Request) {
 	vars := mux.Vars(req)
 	sessionId := vars["sessionId"]
 
-	body := struct{ ImageName string }{}
+	body := struct{ ImageName, Alias string }{}
 
 	json.NewDecoder(req.Body).Decode(&body)
 
@@ -26,7 +26,7 @@ func NewInstance(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	i, err := services.NewInstance(s, body.ImageName)
+	i, err := services.NewInstance(s, body.ImageName, body.Alias)
 	if err != nil {
 		log.Println(err)
 		rw.WriteHeader(http.StatusInternalServerError)

--- a/handlers/reverseproxy.go
+++ b/handlers/reverseproxy.go
@@ -11,11 +11,14 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/play-with-docker/play-with-docker/config"
+	"github.com/play-with-docker/play-with-docker/services"
 )
 
 func getTargetInfo(vars map[string]string, req *http.Request) (string, string) {
 	node := vars["node"]
 	port := vars["port"]
+	alias := vars["alias"]
+	sessionPrefix := vars["session"]
 	hostPort := strings.Split(req.Host, ":")
 
 	// give priority to the URL host port
@@ -23,6 +26,13 @@ func getTargetInfo(vars map[string]string, req *http.Request) (string, string) {
 		port = hostPort[1]
 	} else if port == "" {
 		port = "80"
+	}
+
+	if alias != "" {
+		instance := services.FindInstanceByAlias(sessionPrefix, alias)
+		if instance != nil {
+			node = instance.IP
+		}
 	}
 
 	if strings.HasPrefix(node, "pwd") {

--- a/handlers/reverseproxy.go
+++ b/handlers/reverseproxy.go
@@ -32,6 +32,7 @@ func getTargetInfo(vars map[string]string, req *http.Request) (string, string) {
 		instance := services.FindInstanceByAlias(sessionPrefix, alias)
 		if instance != nil {
 			node = instance.IP
+			return node, port
 		}
 	}
 

--- a/services/instance.go
+++ b/services/instance.go
@@ -34,6 +34,7 @@ type Instance struct {
 	IsManager    *bool                   `json:"is_manager"`
 	Mem          string                  `json:"mem"`
 	Cpu          string                  `json:"cpu"`
+	Alias        string                  `json:"alias"`
 	Ports        UInt16Slice
 	tempPorts    []uint16         `json:"-"`
 	ServerCert   []byte           `json:"server_cert"`
@@ -96,7 +97,7 @@ func getDindImageName() string {
 	return dindImage
 }
 
-func NewInstance(session *Session, imageName string) (*Instance, error) {
+func NewInstance(session *Session, imageName, alias string) (*Instance, error) {
 	if imageName == "" {
 		imageName = dindImage
 	}
@@ -105,6 +106,9 @@ func NewInstance(session *Session, imageName string) (*Instance, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	instance.Alias = alias
+
 	instance.session = session
 
 	if session.Instances == nil {
@@ -168,6 +172,19 @@ func FindInstanceByIP(ip string) *Instance {
 		for _, i := range s.Instances {
 			if i.IP == ip {
 				return i
+			}
+		}
+	}
+	return nil
+}
+
+func FindInstanceByAlias(sessionPrefix, alias string) *Instance {
+	for id, s := range sessions {
+		if strings.HasPrefix(id, sessionPrefix) {
+			for _, i := range s.Instances {
+				if i.Alias == alias {
+					return i
+				}
 			}
 		}
 	}

--- a/services/session.go
+++ b/services/session.go
@@ -280,16 +280,6 @@ func GetSession(sessionId string) *Session {
 	return s
 }
 
-func GetSessionByPrefix(sessionPrefix string) *Session {
-
-	for id, s := range sessions {
-		if strings.HasPrefix(id, sessionPrefix) {
-			return s
-		}
-	}
-	return nil
-}
-
 func setGauges() {
 	var ins float64
 	var cli float64

--- a/services/session.go
+++ b/services/session.go
@@ -280,6 +280,16 @@ func GetSession(sessionId string) *Session {
 	return s
 }
 
+func GetSessionByPrefix(sessionPrefix string) *Session {
+
+	for id, s := range sessions {
+		if strings.HasPrefix(id, sessionPrefix) {
+			return s
+		}
+	}
+	return nil
+}
+
 func setGauges() {
 	var ins float64
 	var cli float64


### PR DESCRIPTION
The POST to create a instance now provides an `alias` field which
then can be used to access the instance services through the following
URL:

`http://<alias>-<short_session>-<port>.<tld>`

When creating a session you can now send an `alias`

@xetorthio 