### PR TITLE
Remove close alert when user is signed out

### DIFF
--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -23,7 +23,7 @@
         $scope.newInstanceBtnText = '+ Add new instance';
         $scope.deleteInstanceBtnText = 'Delete';
         $scope.isInstanceBeingDeleted = false;
-        
+
         var selectedKeyboardShortcuts = KeyboardShortcutService.getCurrentShortcuts();
 
         angular.element($window).bind('resize', function() {

--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -55,6 +55,8 @@
 	KeyboardShortcutService.setResizeFunc($scope.resize);
 
         $scope.closeSession = function() {
+            // Remove alert before closing browser tab
+            window.onbeforeunload = null;
             $scope.socket.emit('session close');
         }
 


### PR DESCRIPTION
When you sign out, the browser still asks you if you're ok with closing the tab since you'll lose your work.

This doesn't make sense since the session is already destroyed and it just forces another dialog, and since it's a browser dialog you can't just kill the tab.