### PR TITLE
Added response headers to set content types for api resources

### DIFF
--- a/handlers/get_instance_images.go
+++ b/handlers/get_instance_images.go
@@ -9,5 +9,6 @@ import (
 
 func GetInstanceImages(rw http.ResponseWriter, req *http.Request) {
 	instanceImages := services.InstanceImages()
+	rw.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(rw).Encode(instanceImages)
 }

--- a/handlers/get_session.go
+++ b/handlers/get_session.go
@@ -19,5 +19,6 @@ func GetSession(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(rw).Encode(session)
 }

--- a/handlers/new_instance.go
+++ b/handlers/new_instance.go
@@ -33,6 +33,7 @@ func NewInstance(rw http.ResponseWriter, req *http.Request) {
 		return
 		//TODO: Set a status error
 	} else {
+		rw.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(rw).Encode(i)
 	}
 }


### PR DESCRIPTION
Noticed a few API resources that didn't have the header set. Makes some JavaScript-related stuff easier when the headers are set.