### PR TITLE
Revert "updating README to suggest using docker stack deploy instead of docke…"

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ Start the Docker daemon on your machine and run `docker pull franela/dind`.
 
 2) `go get -v -d -t ./...`
 
-3) Start PWD as a container with `docker stack deploy -c docker-compose.yml pwd`.
+3) Start PWD as a container with docker-compose up.
 
-5) Point to http://localhost and click "New Instance".
+5) Point to http://localhost and click "New Instance"
 
 Notes:
 


### PR DESCRIPTION
Reverts play-with-docker/play-with-docker#177

Hey @ManoMarks I'm reverting this PR as PWD in dev is not intended to be deployed as a service. The reason for this is because services have a use-case in general than standard containers and PWD components don't follow the service pattern. 

I saw your comment that compose wasn't working and stack deployed fix it. We need to try to understand why compose wasn't working in this particular case. 

Let's try no to auto-merge PR's into the repo to avoid unnecessary reverts afterwards.