### PR TITLE
Make me endpoint accessible through CORS.

### DIFF
--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -68,8 +68,8 @@ func Register(extend HandlerExtender) {
 		http.ServeFile(rw, r, "./www/landing.html")
 	}).Methods("GET")
 
-	r.HandleFunc("/users/me", LoggedInUser).Methods("GET")
-	r.HandleFunc("/users/{userId}", GetUser).Methods("GET")
+	corsRouter.HandleFunc("/users/me", LoggedInUser).Methods("GET")
+	r.HandleFunc("/users/{userId:^(?me)}", GetUser).Methods("GET")
 	r.HandleFunc("/oauth/providers", ListProviders).Methods("GET")
 	r.HandleFunc("/oauth/providers/{provider}/login", Login).Methods("GET")
 	r.HandleFunc("/oauth/providers/{provider}/callback", LoginCallback).Methods("GET")


### PR DESCRIPTION
Because the standard router was triggering before the cors one,
a regex not to match `/me` is needed

@xetorthio :bell: 