### PR TITLE
Playground management endpoints

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ var MaxLoadAvg float64
 var ForceTLS bool
 var Providers map[string]*oauth2.Config
 var SecureCookie *securecookie.SecureCookie
+var AdminToken string
 
 var GithubClientID, GithubClientSecret string
 var FacebookClientID, FacebookClientSecret string
@@ -71,6 +72,7 @@ func ParseFlags() {
 	flag.StringVar(&DockerClientSecret, "oauth-docker-client-secret", "", "Docker OAuth Client Secret")
 
 	flag.StringVar(&PlaygroundDomain, "playground-domain", "localhost", "Domain to use for the playground")
+	flag.StringVar(&AdminToken, "admin-token", "", "Token to validate admin user for admin endpoints")
 
 	flag.Parse()
 

--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -75,6 +75,8 @@ func Register(extend HandlerExtender) {
 	r.HandleFunc("/oauth/providers", ListProviders).Methods("GET")
 	r.HandleFunc("/oauth/providers/{provider}/login", Login).Methods("GET")
 	r.HandleFunc("/oauth/providers/{provider}/callback", LoginCallback).Methods("GET")
+	r.HandleFunc("/playgrounds", NewPlayground).Methods("PUT")
+	r.HandleFunc("/playgrounds", ListPlaygrounds).Methods("GET")
 
 	corsRouter.HandleFunc("/", NewSession).Methods("POST")
 

--- a/handlers/new_playground.go
+++ b/handlers/new_playground.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/play-with-docker/play-with-docker/config"
+	"github.com/play-with-docker/play-with-docker/pwd/types"
+)
+
+func NewPlayground(rw http.ResponseWriter, req *http.Request) {
+	if !validateToken(req) {
+		rw.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	var playground types.Playground
+
+	err := json.NewDecoder(req.Body).Decode(&playground)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "Error creating playground. Got: %v", err)
+		return
+	}
+
+	newPlayground, err := core.PlaygroundNew(playground)
+	if err != nil {
+		rw.WriteHeader(http.StatusBadRequest)
+		fmt.Fprintf(rw, "Error creating playground. Got: %v", err)
+		return
+	}
+
+	json.NewEncoder(rw).Encode(newPlayground)
+}
+
+func ListPlaygrounds(rw http.ResponseWriter, req *http.Request) {
+	if !validateToken(req) {
+		rw.WriteHeader(http.StatusForbidden)
+		return
+	}
+
+	playgrounds, err := core.PlaygroundList()
+	if err != nil {
+		log.Printf("Error listing playgrounds. Got: %v\n", err)
+		rw.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(rw).Encode(playgrounds)
+}
+
+func validateToken(req *http.Request) bool {
+	_, password, ok := req.BasicAuth()
+	if !ok {
+		return false
+	}
+
+	if password != config.AdminToken {
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Add list playgrounds and create/update playground endpoints.
User is expected to send a predefined token as basic auth password.