### PR TITLE
Playground events

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -15,13 +15,14 @@ var (
 	SESSION_END              = EventType("session end")
 	SESSION_READY            = EventType("session ready")
 	SESSION_BUILDER_OUT      = EventType("session builder out")
+	PLAYGROUND_NEW           = EventType("playground_new")
 )
 
-type Handler func(sessionId string, args ...interface{})
-type AnyHandler func(eventType EventType, sessionId string, args ...interface{})
+type Handler func(id string, args ...interface{})
+type AnyHandler func(eventType EventType, id string, args ...interface{})
 
 type EventApi interface {
-	Emit(name EventType, sessionId string, args ...interface{})
+	Emit(name EventType, id string, args ...interface{})
 	On(name EventType, handler Handler)
 	OnAny(handler AnyHandler)
 }

--- a/pwd/playground.go
+++ b/pwd/playground.go
@@ -3,6 +3,7 @@ package pwd
 import (
 	"log"
 
+	"github.com/play-with-docker/play-with-docker/event"
 	"github.com/play-with-docker/play-with-docker/pwd/types"
 	"github.com/satori/go.uuid"
 )
@@ -14,6 +15,7 @@ func (p *pwd) PlaygroundNew(playground types.Playground) (*types.Playground, err
 		return nil, err
 	}
 
+	p.event.Emit(event.PLAYGROUND_NEW, playground.Id)
 	return &playground, nil
 }
 

--- a/pwd/playground_test.go
+++ b/pwd/playground_test.go
@@ -25,6 +25,8 @@ func TestPlaygroundNew(t *testing.T) {
 	ipf := provisioner.NewInstanceProvisionerFactory(provisioner.NewWindowsASG(_f, _s), provisioner.NewDinD(_g, _f, _s))
 	sp := provisioner.NewOverlaySessionProvisioner(_f)
 
+	var nilArgs []interface{}
+	_e.M.On("Emit", event.PLAYGROUND_NEW, uuid.NewV5(uuid.NamespaceOID, "localhost").String(), nilArgs).Return()
 	_s.On("PlaygroundPut", mock.AnythingOfType("*types.Playground")).Return(nil)
 
 	p := NewPWD(_f, _e, _s, sp, ipf)
@@ -52,6 +54,8 @@ func TestPlaygroundGet(t *testing.T) {
 	_g := &id.MockGenerator{}
 	_e := &event.Mock{}
 
+	var nilArgs []interface{}
+	_e.M.On("Emit", event.PLAYGROUND_NEW, uuid.NewV5(uuid.NamespaceOID, "localhost").String(), nilArgs).Return()
 	_s.On("PlaygroundPut", mock.AnythingOfType("*types.Playground")).Return(nil)
 
 	ipf := provisioner.NewInstanceProvisionerFactory(provisioner.NewWindowsASG(_f, _s), provisioner.NewDinD(_g, _f, _s))
@@ -86,6 +90,8 @@ func TestPlaygroundFindByDomain(t *testing.T) {
 	_g := &id.MockGenerator{}
 	_e := &event.Mock{}
 
+	var nilArgs []interface{}
+	_e.M.On("Emit", event.PLAYGROUND_NEW, uuid.NewV5(uuid.NamespaceOID, "localhost").String(), nilArgs).Return()
 	_s.On("PlaygroundPut", mock.AnythingOfType("*types.Playground")).Return(nil)
 
 	ipf := provisioner.NewInstanceProvisionerFactory(provisioner.NewWindowsASG(_f, _s), provisioner.NewDinD(_g, _f, _s))
@@ -120,6 +126,9 @@ func TestPlaygroundList(t *testing.T) {
 	_g := &id.MockGenerator{}
 	_e := &event.Mock{}
 
+	var nilArgs []interface{}
+	_e.M.On("Emit", event.PLAYGROUND_NEW, uuid.NewV5(uuid.NamespaceOID, "localhost1").String(), nilArgs).Return()
+	_e.M.On("Emit", event.PLAYGROUND_NEW, uuid.NewV5(uuid.NamespaceOID, "localhost2").String(), nilArgs).Return()
 	_s.On("PlaygroundPut", mock.AnythingOfType("*types.Playground")).Return(nil)
 
 	ipf := provisioner.NewInstanceProvisionerFactory(provisioner.NewWindowsASG(_f, _s), provisioner.NewDinD(_g, _f, _s))

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -308,6 +308,15 @@ func (s *scheduler) Start() error {
 		instance := &types.Instance{Name: instanceName}
 		s.unscheduleInstance(instance)
 	})
+	s.event.On(event.PLAYGROUND_NEW, func(playgroundId string, args ...interface{}) {
+		s.mx.Lock()
+		defer s.mx.Unlock()
+
+		log.Printf("EVENT: Playground New %s\n", playgroundId)
+
+		// We just update all playgrounds we manage to be safe. This is pretty fast anyway and this event should be fairly rare
+		s.updatePlaygrounds()
+	})
 	s.started = true
 
 	return nil


### PR DESCRIPTION
When playground is created or modified it emits an event.
The scheduler listens to playground events and updates it's
configuration immediately.