### PR TITLE
Cannot create containers when the browser is not maximized

### DIFF
--- a/www/k8s/index.html
+++ b/www/k8s/index.html
@@ -40,7 +40,7 @@
                   class="md-sidenav-left"
                   md-component-id="left"
                   md-theme="kube"
-                  md-is-locked-open="$mdMedia('gt-sm')"
+                  md-is-locked-open="true"
                   md-whiteframe="4" layout="column">
 
                 <md-toolbar class="md-accent md-hue-3">


### PR DESCRIPTION
Hi, first time visiting the site and I initially thought it was broken. The sidebar was hidden so I couldn't figure out  how to add instances to the playground. This change locks the sidebar open; I did not test it.