### PR TITLE
Feature/support systemd

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ var ForceTLS bool
 var SecureCookie *securecookie.SecureCookie
 var AdminToken string
 var ExecAttachCmd string
+var UseHostCgroup bool
 
 var PlaygroundDomain string
 
@@ -64,6 +65,7 @@ func ParseFlags() {
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
 	flag.StringVar(&ExecAttachCmd, "exec-attach-cmd", "", "Exec that should be executed on attaching terminal")
+	flag.BoolVar(&UseHostCgroup, "use-host-cgroup", false, "Mount /sys/fs/cgroup in container, required for systemd")
 	flag.Parse()
 
 	SecureCookie = securecookie.New([]byte(CookieHashKey), []byte(CookieBlockKey))

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,7 @@ var MaxLoadAvg float64
 var ForceTLS bool
 var SecureCookie *securecookie.SecureCookie
 var AdminToken string
+var ExecAttachCmd string
 
 var PlaygroundDomain string
 
@@ -62,7 +63,7 @@ func ParseFlags() {
 	flag.StringVar(&AdminToken, "admin-token", "", "Token to validate admin user for admin endpoints")
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
-
+	flag.StringVar(&ExecAttachCmd, "exec-attach-cmd", "", "Exec that should be executed on attaching terminal")
 	flag.Parse()
 
 	SecureCookie = securecookie.New([]byte(CookieHashKey), []byte(CookieBlockKey))

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -395,7 +395,7 @@ func (d *docker) ContainerCreate(opts CreateContainerOpts) (err error) {
 			return err
 		}
 
-		h.Binds = append(h.Binds, "/sys/fs/cgroup:/sys/fs/cgroup")
+		h.Binds = append(h.Binds, "/sys/fs/cgroup:/sys/fs/cgroup:ro")
 		defer func() {
 			if err != nil {
 				d.c.VolumeRemove(context.Background(), opts.SessionId, true)

--- a/provisioner/dind.go
+++ b/provisioner/dind.go
@@ -75,6 +75,7 @@ func (d *DinD) InstanceNew(session *types.Session, conf types.InstanceConfig) (*
 		ServerKey:     conf.ServerKey,
 		CACert:        conf.CACert,
 		HostFQDN:      conf.PlaygroundFQDN,
+		UseHostCgroup: conf.UseHostCgroup,
 		Privileged:    true,
 		Networks:      []string{session.Id},
 	}
@@ -108,6 +109,7 @@ func (d *DinD) InstanceNew(session *types.Session, conf types.InstanceConfig) (*
 	instance.ProxyHost = router.EncodeHost(session.Id, instance.RoutableIP, router.HostOpts{})
 	instance.SessionHost = session.Host
 	instance.ExecAttachCmd = conf.ExecAttachCmd
+	instance.UseHostCgroup = conf.UseHostCgroup
 
 	return instance, nil
 }

--- a/pwd/instance.go
+++ b/pwd/instance.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/play-with-docker/play-with-docker/config"
@@ -105,6 +106,10 @@ func (p *pwd) InstanceNew(session *types.Session, conf types.InstanceConfig) (*t
 
 	if config.ForceTLS {
 		conf.Tls = true
+	}
+
+	if config.ExecAttachCmd != "" {
+		conf.ExecAttachCmd = strings.Split(config.ExecAttachCmd, " ")
 	}
 
 	instance, err := prov.InstanceNew(session, conf)

--- a/pwd/instance.go
+++ b/pwd/instance.go
@@ -112,6 +112,8 @@ func (p *pwd) InstanceNew(session *types.Session, conf types.InstanceConfig) (*t
 		conf.ExecAttachCmd = strings.Split(config.ExecAttachCmd, " ")
 	}
 
+	conf.UseHostCgroup = config.UseHostCgroup
+
 	instance, err := prov.InstanceNew(session, conf)
 	if err != nil {
 		log.Println(err)

--- a/pwd/session.go
+++ b/pwd/session.go
@@ -42,6 +42,7 @@ type SessionSetupInstanceConf struct {
 	Type           string     `json:"type"`
 	Run            [][]string `json:"run"`
 	Tls            bool       `json:"tls"`
+	ExecAttachCmd  []string   `json:"exec_attach_cmd"`
 }
 
 func (p *pwd) SessionNew(ctx context.Context, config types.SessionConfig) (*types.Session, error) {
@@ -246,6 +247,7 @@ func (p *pwd) SessionSetup(session *types.Session, sconf SessionSetupConf) error
 				PlaygroundFQDN: sconf.PlaygroundFQDN,
 				Type:           conf.Type,
 				Tls:            conf.Tls,
+				ExecAttachCmd:  conf.ExecAttachCmd,
 			}
 			i, err := p.InstanceNew(session, instanceConf)
 			if err != nil {

--- a/pwd/types/instance.go
+++ b/pwd/types/instance.go
@@ -22,6 +22,7 @@ type Instance struct {
 	ctx           context.Context `json:"-" bson:"-"`
 	ExecAttachCmd []string        `json:"exec_attach_cmd" bson:"exec_attach_cmd"`
 	ExecID        string          `json:"-" bson:"-"`
+	UseHostCgroup bool            `json:"use_host_cgroup" bson:"use_host_cgroup"`
 }
 
 type WindowsInstance struct {
@@ -41,4 +42,5 @@ type InstanceConfig struct {
 	PlaygroundFQDN string
 	Type           string
 	ExecAttachCmd  []string
+	UseHostCgroup  bool
 }

--- a/pwd/types/instance.go
+++ b/pwd/types/instance.go
@@ -3,23 +3,25 @@ package types
 import "context"
 
 type Instance struct {
-	Name        string          `json:"name" bson:"name"`
-	Image       string          `json:"image" bson:"image"`
-	Hostname    string          `json:"hostname" bson:"hostname"`
-	IP          string          `json:"ip" bson:"ip"`
-	RoutableIP  string          `json:"routable_ip" bson:"routable_id"`
-	ServerCert  []byte          `json:"server_cert" bson:"server_cert"`
-	ServerKey   []byte          `json:"server_key" bson:"server_key"`
-	CACert      []byte          `json:"ca_cert" bson:"ca_cert"`
-	Cert        []byte          `json:"cert" bson:"cert"`
-	Key         []byte          `json:"key" bson:"key"`
-	Tls         bool            `json:"tls" bson:"tls"`
-	SessionId   string          `json:"session_id" bson:"session_id"`
-	ProxyHost   string          `json:"proxy_host" bson:"proxy_host"`
-	SessionHost string          `json:"session_host" bson:"session_host"`
-	Type        string          `json:"type" bson:"type"`
-	WindowsId   string          `json:"-" bson:"windows_id"`
-	ctx         context.Context `json:"-" bson:"-"`
+	Name          string          `json:"name" bson:"name"`
+	Image         string          `json:"image" bson:"image"`
+	Hostname      string          `json:"hostname" bson:"hostname"`
+	IP            string          `json:"ip" bson:"ip"`
+	RoutableIP    string          `json:"routable_ip" bson:"routable_id"`
+	ServerCert    []byte          `json:"server_cert" bson:"server_cert"`
+	ServerKey     []byte          `json:"server_key" bson:"server_key"`
+	CACert        []byte          `json:"ca_cert" bson:"ca_cert"`
+	Cert          []byte          `json:"cert" bson:"cert"`
+	Key           []byte          `json:"key" bson:"key"`
+	Tls           bool            `json:"tls" bson:"tls"`
+	SessionId     string          `json:"session_id" bson:"session_id"`
+	ProxyHost     string          `json:"proxy_host" bson:"proxy_host"`
+	SessionHost   string          `json:"session_host" bson:"session_host"`
+	Type          string          `json:"type" bson:"type"`
+	WindowsId     string          `json:"-" bson:"windows_id"`
+	ctx           context.Context `json:"-" bson:"-"`
+	ExecAttachCmd []string        `json:"exec_attach_cmd" bson:"exec_attach_cmd"`
+	ExecID        string          `json:"-" bson:"-"`
 }
 
 type WindowsInstance struct {
@@ -38,4 +40,5 @@ type InstanceConfig struct {
 	Tls            bool
 	PlaygroundFQDN string
 	Type           string
+	ExecAttachCmd  []string
 }


### PR DESCRIPTION
Changes for supporting systemd. This changes add the possibility to
- Do Docker exec in favor of Docker attach. When `ExecAttachCmd` is set with an value that command will be used for exec.
- Mount /sys/fs/cgroup from host in container. It is required to have this mounted to have Systemd working. See also https://serverfault.com/a/813309.

All new options are optionally. If not set it should still works as it was before the merge.