### PR TITLE
Add net-alias

### DIFF
--- a/provisioner/dind.go
+++ b/provisioner/dind.go
@@ -77,6 +77,7 @@ func (d *DinD) InstanceNew(session *types.Session, conf types.InstanceConfig) (*
 		HostFQDN:      conf.PlaygroundFQDN,
 		Privileged:    true,
 		Networks:      []string{session.Id},
+		NetAlias:      []string{conf.Hostname},
 	}
 
 	dockerClient, err := d.factory.GetForSession(session)

--- a/provisioner/overlay.go
+++ b/provisioner/overlay.go
@@ -42,7 +42,9 @@ func (p *overlaySessionProvisioner) SessionNew(ctx context.Context, s *types.Ses
 	}
 	log.Printf("Network [%s] created for session [%s]\n", s.Id, s.Id)
 
-	ip, err := dockerClient.NetworkConnect(config.L2ContainerName, s.Id, s.PwdIpAddress)
+	aliases := []string{config.PWDContainerName}
+
+	ip, err := dockerClient.NetworkConnect(config.L2ContainerName, s.Id, s.PwdIpAddress, aliases)
 	if err != nil {
 		log.Println(err)
 		return err


### PR DESCRIPTION
This change will make it possible to ping other nodes on hostname. It used Docker DNS when start with Docker-compose. For example, when you start node1 and node2 you can do on node2:
```
ping node1
```
And it will succeed.