### PR TITLE
Added non_privileged key to Playground and added config option

### DIFF
--- a/api.go
+++ b/api.go
@@ -52,7 +52,7 @@ func main() {
 		log.Fatalf("Cannot parse duration %s. Got: %v", config.DefaultSessionDuration, err)
 	}
 
-	playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: config.DefaultDinDImage, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, AvailableDinDInstanceImages: []string{config.DefaultDinDImage}, Tasks: []string{".*"}}
+	playground := types.Playground{Domain: config.PlaygroundDomain, DefaultDinDInstanceImage: config.DefaultDinDImage, AllowWindowsInstances: config.NoWindows, DefaultSessionDuration: d, AvailableDinDInstanceImages: []string{config.DefaultDinDImage}, Tasks: []string{".*"}, NonPrivileged: config.NonPrivileged}
 	if _, err := core.PlaygroundNew(playground); err != nil {
 		log.Fatalf("Cannot create default playground. Got: %v", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ var PlaygroundDomain string
 
 var SegmentId string
 
+var NonPrivileged bool
+
 // TODO move this to a sync map so it can be updated on demand when the configuration for a playground changes
 var Providers = map[string]map[string]*oauth2.Config{}
 
@@ -60,6 +62,7 @@ func ParseFlags() {
 
 	flag.StringVar(&PlaygroundDomain, "playground-domain", "localhost", "Domain to use for the playground")
 	flag.StringVar(&AdminToken, "admin-token", "", "Token to validate admin user for admin endpoints")
+	flag.BoolVar(&NonPrivileged, "non-privileged", false, "Run containers in privileged mode")
 
 	flag.StringVar(&SegmentId, "segment-id", "", "Segment id to post metrics")
 

--- a/provisioner/dind.go
+++ b/provisioner/dind.go
@@ -42,8 +42,8 @@ func checkHostnameExists(sessionId, hostname string, instances []*types.Instance
 }
 
 func (d *DinD) InstanceNew(session *types.Session, conf types.InstanceConfig) (*types.Instance, error) {
+	playground, err := d.storage.PlaygroundGet(session.PlaygroundId)
 	if conf.ImageName == "" {
-		playground, err := d.storage.PlaygroundGet(session.PlaygroundId)
 		if err != nil {
 			return nil, err
 		}
@@ -77,6 +77,10 @@ func (d *DinD) InstanceNew(session *types.Session, conf types.InstanceConfig) (*
 		HostFQDN:      conf.PlaygroundFQDN,
 		Privileged:    true,
 		Networks:      []string{session.Id},
+	}
+
+	if playground.NonPrivileged {
+		opts.Privileged = false
 	}
 
 	dockerClient, err := d.factory.GetForSession(session)

--- a/pwd/types/playground.go
+++ b/pwd/types/playground.go
@@ -88,4 +88,5 @@ type Playground struct {
 	DockerClientID              string           `json:"docker_client_id" bson:"docker_client_id"`
 	DockerClientSecret          string           `json:"docker_client_secret" bson:"docker_client_secret"`
 	MaxInstances                int              `json:"max_instances" bson:"max_instances"`
+	NonPrivileged               bool             `json:"non_privileged" bson:"non_privileged"`
 }


### PR DESCRIPTION
This change added the config option '-non-privileged' which will result in an playground with the containers start in non privileged mode (so it won't run Docker, but is more secure). Also in the Playground API there is now an extra key non_privileged which, as admin, can be set.