### PR TITLE
Add "Open Port" button

### DIFF
--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -389,6 +389,14 @@
       });
     }
 
+    $scope.openPort = function(instance) {
+      var port = prompt('What port would you like to open?');
+      if (!port) return;
+      
+      var url = $scope.getProxyUrl(instance, port);
+      window.open(url, '_blank');
+    }
+
     $scope.getProxyUrl = function(instance, port) {
       var url = 'http://' + instance.proxy_host + '-' + port + '.direct.' + $scope.host;
 

--- a/www/default/index.html
+++ b/www/default/index.html
@@ -93,8 +93,11 @@
                                <label>IP</label>
                                <input ng-model="instance.ip" type="text" readonly="readonly">
                              </md-input-container>
+                             <md-button class="md-raised" ng-click="openPort(instance)">
+                                Open Port
+                             </md-button>
                              <md-chips ng-model="instance.ports" name="port" readonly="true" md-removable="false">
-                               <md-chip-template>
+                               <md-chip-template> 
                                <strong><a href="{{getProxyUrl(instance, $chip)}}" title="{{getProxyUrl(instance, $chip)}}" target="_blank">{{$chip}}</a></strong>
                                </md-chip-template>
                              </md-chips>


### PR DESCRIPTION
Since there have still been incidents in which exposed ports don't show up on the screen (not sure why), I decided to add a quick "Open Port" button to allow someone to simply type in the number and open the port without needing to figure out how to construct the URL.

I ran it locally and it worked, but certainly open to feedback 👍 