### PR TITLE
Allow users to overwrite the port information in the PWD lab.

### DIFF
--- a/www/assets/app.js
+++ b/www/assets/app.js
@@ -193,9 +193,17 @@
 		base = 'wss://';
 	}
 	base += window.location.host;
-	if (window.location.port) {
+
+	// if PWD server use non-default 80 port, the new port could be set here to create the correct base link.
+	// otherwise, leave the variable empty.
+	// var port_overwrite = '5010';
+	var port_overwrite = '';
+	if (port_overwrite) {
+		base += ':' + port_overwrite;
+	} else if (window.location.port) {
 		base += ':' + window.location.port;
 	}
+
 
 	var socket = new ReconnectingWebSocket(base + '/sessions/' + sessionId + '/ws/', null, {reconnectInterval: 1000});
 	socket.listeners = {};


### PR DESCRIPTION
In the PWD lab, the port is determined by ```window.location.port```. However, it's not always correct.
When the user has multiple applications on the same server, to avoid port conflicts, PWD could be deployed on a non-default port, such as 5010. For convenience, this port won't be exposed directly. Instead, Apache/Nginx will forward the requests to PWD on port 80 to the PWD port 5010. Thus, PWD is running like on port 80 and no special port needs to be specified.
In this case, ```window.location.port``` thinks PWD runs on port 80 and won't set up the correct information. The generated base link in ```/www/asserts/app.js``` is incorrect. Instead of ```my-pwd.com:5010```, ```my-pwd.com``` is provided. Then in the PWD lab, it will keep reconnecting the PWD server forever.
Therefore, a variable should be set to overwrite the port number manually. If such a variable is specified, it will be used and ```window.location.port``` is ignored.