### PR TITLE
Update to `xt_ipvs` instead of `xt_ipv`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ docker run hello-world
 
 # Load the IPVS kernel module. Because swarms are created in dind,
 # the daemon won't load it automatically
-sudo modprobe xt_ipv
+sudo modprobe xt_ipvs
 
 # Ensure Docker daemon is running in swarm mode
 docker swarm init


### PR DESCRIPTION
I hope this one is `xt_ipvs`, since I tried xt_ipv on 
1. centos 7
2. Ubuntu 18
     