### PR TITLE
Update the GitHub actions to the latest version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@722adc63f1aa60a57ec37892e133b1d319cae598
+      uses: actions/checkout@v2
     - name: Install Go
-      uses: actions/setup-go@9fbc767707c286e568c92927bbf57d76b73e0892
+      uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go_version }}
     - name: Generate


### PR DESCRIPTION
The current action version caused a warning that `set-env` command is deprecated and will be disabled soon.

The annotation from running current CI  in GitHub Actions shows:
> The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/