### PR TITLE
added oidc provider

### DIFF
--- a/handlers/bootstrap.go
+++ b/handlers/bootstrap.go
@@ -17,6 +17,7 @@ import (
 
 	"golang.org/x/crypto/acme/autocert"
 	"golang.org/x/oauth2"
+	"github.com/coreos/go-oidc"
 
 	gh "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
@@ -284,5 +285,23 @@ func initOauthProviders(p *types.Playground) {
 		}
 
 		config.Providers[p.Id]["docker"] = conf
+	}
+	if p.OidcClientID != "" && p.OidcClientSecret != "" {
+		
+		ctx := context.Background()
+		endpoint := p.OidcHost
+		oidcProvider, err := oidc.NewProvider(ctx, fmt.Sprintf("https://%s", endpoint))
+		if err != nil {
+			log.Fatalf("Could not connect to oidc provider. Got %s", err )
+		}
+
+		conf := &oauth2.Config{
+			ClientID:     p.OidcClientID,
+			ClientSecret: p.OidcClientSecret,
+			Scopes:       []string{"openid"},
+			Endpoint:     oidcProvider.Endpoint(),
+		}
+
+		config.Providers[p.Id]["oidc"] = conf
 	}
 }

--- a/pwd/types/playground.go
+++ b/pwd/types/playground.go
@@ -88,6 +88,9 @@ type Playground struct {
 	GoogleClientSecret          string           `json:"google_client_secret" bson:"google_client_secret"`
 	DockerClientID              string           `json:"docker_client_id" bson:"docker_client_id"`
 	DockerClientSecret          string           `json:"docker_client_secret" bson:"docker_client_secret"`
+	OidcClientID                string           `json:"oidc_client_id" bson:"oidc_client_id"`
+	OidcClientSecret            string           `json:"oidc_client_secret" bson:"oidc_client_secret"`
+	OidcHost                    string           `json:"oidc_host" bson:"oidc_host"`
 	AuthRedirectBase            string           `json:"auth_redirect_base" bson:"auth_redirect_base"`
 	DockerHost                  string           `json:"docker_host" bson:"docker_host"`
 	MaxInstances                int              `json:"max_instances" bson:"max_instances"`


### PR DESCRIPTION
Added oidc provider for authentication against self-hosted gitlab or other openid connect providers.
Maybe some further changes are necessary to properly initialize of p.OidcClientID, p.OidcClientSecret and p.OidcHost.