### PR TITLE
PWD: enforce that pwd and l2 are started before haproxy.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,9 @@ services:
             - "80:8080"
         volumes:
             - ./haproxy:/usr/local/etc/haproxy
-
+        depends_on:
+            - pwd
+            - l2
     pwd:
         # pwd daemon container always needs to be named this way
         container_name: pwd


### PR DESCRIPTION
Haproxy has a dependency on pwd and l2 and without enforcing this dependency
solves an issue where the system will start and haproxy will not be able to
resolve the ip address for l2 (see #479).