### PR TITLE
Update kubernetes.repo

### DIFF
--- a/dockerfiles/k8s/kubernetes.repo
+++ b/dockerfiles/k8s/kubernetes.repo
@@ -1,8 +1,7 @@
 [kubernetes]
 name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+baseurl=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/
 enabled=1
 gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg
-        https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+gpgkey=https://pkgs.k8s.io/core:/stable:/v1.28/rpm/repodata/repomd.xml.key
+exclude=kubelet kubeadm kubectl cri-tools kubernetes-cni


### PR DESCRIPTION
As provided by official documentation the old repositories are unavailable since january 2024

https://kubernetes.io/blog/2023/08/15/pkgs-k8s-io-introduction/