### PR TITLE
Update deprecation link to point to labs on guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # play-with-docker
 
 > [!NOTE]
-> **Deprecation notice:** the Play with Docker/Kubernetes systems will be unavailable starting March 1, 2026. Please visit [Docker Docs](https://docs.docker.com/guides/) for supported labs and guides.
+> **Deprecation notice:** the Play with Docker/Kubernetes systems will be unavailable starting March 1, 2026. Please visit [Docker Docs](https://docs.docker.com/guides/?tags=labs) for supported labs and guides.
 
 Play With Docker gives you the experience of having a free Alpine Linux Virtual Machine in the cloud
 where you can build and run Docker containers and even create clusters with Docker features like Swarm Mode.

--- a/handlers/www/default/index.html
+++ b/handlers/www/default/index.html
@@ -37,7 +37,7 @@
             </section>
 
             <section class="disconnected" layout="row" layout-align="center center" style="padding: 1em;">
-                <strong>Deprecation notice:</strong> Play with Docker will be unavailable starting March 1, 2026. Visit <a href="https://docs.docker.com/guides/">Docker Docs</a> for supported labs and guides.
+                <strong>Deprecation notice:</strong>&nbsp;Play with Docker will be unavailable starting March 1, 2026. Visit&nbsp;<a href="https://docs.docker.com/guides/?tags=labs">Docker Docs</a>&nbsp;for supported labs and guides.
             </section>
 
             <section id="popupContainer" layout="row" flex ng-if="isAlive">

--- a/handlers/www/default/landing.html
+++ b/handlers/www/default/landing.html
@@ -37,7 +37,7 @@
         <p class="lead">A simple, interactive and fun playground to learn Docker</p>
 
         <div class="alert alert-warning" role="alert">
-          <strong>Deprecation notice:</strong> Play with Docker will be unavailable starting March 1, 2026. Visit <a href="https://docs.docker.com/guides/">Docker Docs</a> for supported labs and guides.
+          <strong>Deprecation notice:</strong>&nbsp;Play with Docker will be unavailable starting March 1, 2026. Visit&nbsp;<a href="https://docs.docker.com/guides/?tags=labs">Docker Docs</a>&nbsp;for supported labs and guides.
         </div>
 
         <div ng-hide="loggedIn" class="btn-group" role="group">

--- a/handlers/www/k8s/index.html
+++ b/handlers/www/k8s/index.html
@@ -32,7 +32,7 @@
             </section>
 
             <section class="disconnected" layout="row" layout-align="center center" style="padding: 1em;">
-                <strong>Deprecation notice:</strong> Play with Kubernetes will be unavailable starting March 1, 2026. Visit <a href="https://docs.docker.com/guides/">Docker Docs</a> for supported labs and guides.
+                <strong>Deprecation notice:</strong>&nbsp;Play with Kubernetes will be unavailable starting March 1, 2026. Visit&nbsp;<a href="https://docs.docker.com/guides/?tags=labs">Docker Docs</a>&nbsp;for supported labs and guides.
             </section>
 
             <section ng-if="!connected" class="disconnected" layout="row" layout-align="center center">

--- a/handlers/www/k8s/landing.html
+++ b/handlers/www/k8s/landing.html
@@ -49,7 +49,7 @@
         </p>
         
         <div class="alert alert-warning" role="alert">
-          <strong>Deprecation notice:</strong> Play with Kubernetes will be unavailable starting March 1, 2026. Visit <a href="https://docs.docker.com/guides/">Docker Docs</a> for supported labs and guides.
+          <strong>Deprecation notice:</strong>&nbsp;Play with Kubernetes will be unavailable starting March 1, 2026. Visit&nbsp;<a href="https://docs.docker.com/guides/?tags=labs">Docker Docs</a>&nbsp;for supported labs and guides.
         </div>
 
         <div ng-hide="loggedIn" class="btn-group" role="group">


### PR DESCRIPTION
Adding tag query parameter to display the labs on Docker Docs.